### PR TITLE
TRITO location_id.yaml EU-collections changed

### DIFF
--- a/translationTables/location_id.yaml
+++ b/translationTables/location_id.yaml
@@ -93,13 +93,13 @@
 +lodman: ref(45)
 46: branchLoc(TRITO, QLEISTEN) # leisten    1. krs-vån Leistén - K114
 +leisten: ref(46)
-47: branchLoc(TRITO, EUBOOK) # euBook     1. krs-vån EU-kokoelma - EU-samling Tiivishyllyt-Kompakthyll
+47: branchLoc(TRITO, QEUBOOK) # euBook     1. krs-vån EU-kokoelma - EU-samling Tiivishyllyt-Kompakthyll
 +euBook: ref(47)
-48: branchLoc(TRITO, EUJOUR) # euJour     1. krs-vån EU-lehdet-tskr Tiivishyllyt-Kompakthyllor EI LAIN
+48: branchLoc(TRITO, JOURNALS) # euJour     1. krs-vån EU-lehdet-tskr Tiivishyllyt-Kompakthyllor EI LAIN
 +euJour: ref(48)
-49: branchLoc(TRITO, EUREF) # euRef      1. krs-vån EU-käsikirjat-referensböcker, EI LAINATA-LÅNAS EJ
+49: branchLoc(KONVERSIO, KONVERSIO) # euRef      1. krs-vån EU-käsikirjat-referensböcker, EI LAINATA-LÅNAS EJ
 +euRef: ref(49)
-50: branchLoc(TRITO, EUSTATREF) # euStatref  1. krs-vån EU-tilastot - EU-statistik, EI LAINATA-LÅNAS EJ
+50: branchLoc(KONVERSIO, KONVERSIO) # euStatref  1. krs-vån EU-tilastot - EU-statistik, EI LAINATA-LÅNAS EJ
 +euStatref: ref(50)
 51: branchLoc(TRITO, TPROJECTS) # Vprojects  Projekti, Ei voi varata-Kan ej reserveras-Cannot be reserved                                                                                                           
 +Vprojects: ref(51)

--- a/translationTables/location_id.yaml
+++ b/translationTables/location_id.yaml
@@ -53,17 +53,17 @@
 +netpubl: ref(25)
 26: branchLoc(TRITO, STATISTICS) # statistics 1. krs-vån Tilastot - Statistik, EI LAINATA - LÅNAS EJ
 +statistics: ref(26)
-27: branchLoc(TRITO, SEREDU) # serEdu     1. krs-vån ED Pedagogik-Kasvatustiede Serier-Sarjat
+27: branchLoc(TRITO, SERIALS) # serEdu     1. krs-vån ED Pedagogik-Kasvatustiede Serier-Sarjat
 +serEdu: ref(27)
-28: branchLoc(TRITO, SERBUS) # serBus     3. krs-vån BU Taloustieteet-Ekonomi-Economics Sarjat-Serier
+28: branchLoc(TRITO, SERIALS) # serBus     3. krs-vån BU Taloustieteet-Ekonomi-Economics Sarjat-Serier
 +serBus: ref(28)
 29: branchLoc(KONVERSIO, KONVERSIO) # serNat     3. krs-vån Vanha luonnontiedekokoelma
 +serNat: ref(29)
-30: branchLoc(TRITO, SERTEC) # serTec     3. krs-vån TE Tekniikka,luonnont.-Teknik,naturvetensk.SERIES                                                                                                           
+30: branchLoc(TRITO, SERIALS) # serTec     3. krs-vån TE Tekniikka,luonnont.-Teknik,naturvetensk.SERIES                                                                                                           
 +serTec: ref(30)
-31: branchLoc(TRITO, SERHUM) # serHum     1. krs-vån HU Humanistiset tieteet-Humaniora Sarjat-Serier
+31: branchLoc(TRITO, SERIALS) # serHum     1. krs-vån HU Humanistiset tieteet-Humaniora Sarjat-Serier
 +serHum: ref(31)
-32: branchLoc(TRITO, SERSOC) # serSoc     4. krs-vån SO Yhteiskuntat.-Samhällsvetensk. Sarjat-Serier
+32: branchLoc(TRITO, SERIALS) # serSoc     4. krs-vån SO Yhteiskuntat.-Samhällsvetensk. Sarjat-Serier
 +serSoc: ref(32)
 33: branchLoc(TRITO, DICTIONARIES) # dictioninf 1. krs-vån-1st floor GE Sanakirjat-Ordböcker-Dictionaries
 +dictioninf: ref(33)


### PR DESCRIPTION
Pieni muutos kokoelmamappaukseen (EU-kokoelmat poistuneet). Mappaustaulukot pitäisi nyt olla OK testausta varten. Voidaanko ajaa uusi mappaustaulukoiden mukainen testikonversio? Nykyisessä testissä kaikki on kokoelmassa KONVERSIO.