### PR TITLE
Update item_statuses.yaml

### DIFF
--- a/translationTables/item_statuses.yaml
+++ b/translationTables/item_statuses.yaml
@@ -26,8 +26,8 @@ Lost--System Applied:   itemlost=2   # 14
 Claims Returned:        itemlost=4   # 15
 Damaged:                damaged=1    # 16
 Withdrawn:              withdrawn=1  # 17
-At Bindery:             notforloan=3 # 18 - #HAMKilla tässä on henkilökuntakokoelmaa (muilla kirjastoilla arvo olisi 3 eli atbindery)
-Cataloging Review:      notforloan=-4 # 19
+At Bindery:             damaged=1 # 18 - #HAMKilla tässä on henkilökuntakokoelmaa (muilla kirjastoilla arvo olisi 3 eli atbindery)
+Cataloging Review:      damaged=2 # 19
 Circulation Review:     notforloan=5 # 20
 Scheduled:              ''           # 21 - #Ei käytössä
 In Process:             notforloan=-2 # 22 - #Hankinnan kautta saapuneiksi käsitellyt


### PR DESCRIPTION
At bindery ja Cataloging Review > vaihdettu Damaged -tiloiksi (helpottaa/nopeuttaa tilojen käyttöä, kun suoraan nidetiedoista voi vaihtaa tilan menemättä niteen muokkaukseen.