### PR TITLE
Vaihdettu asiakkaiden oletuskirjasto

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -42,7 +42,7 @@ defaultReplacementPrice: 25
 organizationISILCode: FI-Helka
 
 # Set the Patron home library to this value for all patrons. Leave empty to use the LocationId-translation table.
-patronHomeLibrary: KK
+patronHomeLibrary: AVOK
 
 # How many expiry years to add for patron account if expiry date is not defined in Voyager
 patronAddExpiryYears: 0


### PR DESCRIPTION
patronHomeLibrary: 
KK->AVOK
Valittu sellainen branch, joka tulee käyttöön location.id -taulussa